### PR TITLE
Make Account.last_modified_time optional

### DIFF
--- a/stellar_model/model/horizon/account.py
+++ b/stellar_model/model/horizon/account.py
@@ -134,7 +134,7 @@ class Account(BaseModel):
     last_modified_ledger: int = Field(
         description="The ID of the last ledger that included changes to this account."
     )
-    last_modified_time: datetime = Field(
+    last_modified_time: Optional[datetime] = Field(
         description="The time of the last ledger that included "
         "changes to this account."
     )


### PR DESCRIPTION
This can happen when a Horizon node did not completely sync the history

See issue #18