### PR TITLE
Add EffectResponse for parsing singular effects

### DIFF
--- a/stellar_model/response/effect_response.py
+++ b/stellar_model/response/effect_response.py
@@ -1,0 +1,36 @@
+from pydantic import BaseModel
+
+from stellar_model import __issues__
+from stellar_model.model.horizon.effects import _EFFECT_TYPE_I_MAP
+from stellar_model.model.horizon.effects import _EFFECT_TYPE_UNION
+
+
+__all__ = ["EffectResponse"]
+
+
+class EffectResponse(BaseModel):
+    """
+    Represents single effect response.
+    Can be used for the following endpoint(s):
+        - GET /effects/:effect_id
+    See `Effects <https://developers.stellar.org/api/resources/effects/>`_ on Stellar API Reference.
+    """
+
+    record: _EFFECT_TYPE_UNION
+
+    def __init__(self, **data):
+        if "type_i" not in data:
+            raise ValueError(
+                "Invalid data, `type_i` does not appear in the raw data. "
+                "Please check the raw data first, if the data is correct, "
+                "try to upgrade the library or raise an issue at {__issues__}."
+            )
+        effect_type = data["type_i"]
+        if effect_type not in _EFFECT_TYPE_I_MAP:
+            raise ValueError(
+                f"The type of effect is {effect_type}, which is not currently supported in the version. "
+                f"Please try to upgrade the library or raise an issue at {__issues__}."
+            )
+        parser = _EFFECT_TYPE_I_MAP[effect_type]
+        record = parser.parse_obj(data)
+        super().__init__(record=record)

--- a/tests/response/test_effect_response.py
+++ b/tests/response/test_effect_response.py
@@ -1,0 +1,63 @@
+from unittest import TestCase
+
+from stellar_model import OperationResponse
+from stellar_model.model.horizon.operations import *
+from tests.response import load_horizon_file
+
+
+ops = [
+    {"filename": "create_account.json", "class": CreateAccountOperation},
+    {"filename": "payment.json", "class": PaymentOperation},
+    {
+        "filename": "path_payment_strict_receive.json",
+        "class": PathPaymentStrictReceiveOperation,
+    },
+    {"filename": "manage_sell_offer.json", "class": ManageSellOfferOperation},
+    {
+        "filename": "create_passive_sell_offer.json",
+        "class": CreatePassiveSellOfferOperation,
+    },
+    {"filename": "set_options.json", "class": SetOptionsOperation},
+    {"filename": "change_trust_asset.json", "class": ChangeTrustOperation},
+    {"filename": "change_trust_liquidity_pool_id.json", "class": ChangeTrustOperation},
+    {"filename": "allow_trust.json", "class": AllowTrustOperation},
+    {"filename": "account_merge.json", "class": AccountMergeOperation},
+    # {'filename': 'inflation.json', 'class': InflationOperation},
+    {"filename": "manage_data.json", "class": ManageDataOperation},
+    {"filename": "bump_sequence.json", "class": BumpSequenceOperation},
+    {"filename": "manage_buy_offer.json", "class": ManageBuyOfferOperation},
+    {
+        "filename": "path_payment_strict_send.json",
+        "class": PathPaymentStrictSendOperation,
+    },
+    {
+        "filename": "create_claimable_balance.json",
+        "class": CreateClaimableBalanceOperation,
+    },
+    {
+        "filename": "claim_claimable_balance.json",
+        "class": ClaimClaimableBalanceOperation,
+    },
+    {
+        "filename": "begin_sponsoring_future_reserves.json",
+        "class": BeginSponsoringFutureReservesOperation,
+    },
+    {
+        "filename": "end_sponsoring_future_reserves.json",
+        "class": EndSponsoringFutureReservesOperation,
+    },
+    {"filename": "revoke_sponsorship.json", "class": RevokeSponsorshipOperation},
+    # {'filename': 'clawback.json', 'class': ClawbackOperation},
+    # {'filename': 'clawback_claimable_balance.json', 'class': ClawbackClaimableBalanceOperation},
+    # {'filename': 'set_trust_line_flags.json', 'class': SetTrustLineFlagsOperation}
+]
+
+
+class TestOperationResponse(TestCase):
+    def test_valid(self):
+        for op in ops:
+            raw_data = load_horizon_file(f"operations/{op['filename']}")
+            parsed_data = OperationResponse.parse_obj(raw_data)
+            self.assertTrue(isinstance(parsed_data, OperationResponse))
+            self.assertTrue(isinstance(parsed_data.record, op["class"]))
+            self.assertEqual(raw_data["id"], parsed_data.record.id)


### PR DESCRIPTION
# Description

I've found this to be necessary to parse individual effects for an operation/ledger, as in some cases, the `EffectsResponse` parser breaks when a single effect fails validation.

I've basically modeled this exactly on the `OperationResponse` and have added tests for all supported `Effects` classes.

# Testing

Ran `pytest` suite locally with full success.
